### PR TITLE
fixes for Win64

### DIFF
--- a/xbmc/system.h
+++ b/xbmc/system.h
@@ -94,10 +94,6 @@
  *****************/
 
 #if defined(TARGET_WINDOWS)
-<<<<<<< e2f22cf7d1868a0e8ba19c02772b270cc145bd32
-=======
-//#define HAS_DVD_DRIVE
->>>>>>> Fixed some build issues
 #define HAS_WIN32_NETWORK
 #define HAS_IRSERVERSUITE
 #define HAS_AUDIO

--- a/xbmc/threads/Atomics.cpp
+++ b/xbmc/threads/Atomics.cpp
@@ -237,7 +237,8 @@ long AtomicAdd(volatile long* pAddr, long amount)
   return atomic_add(amount, pAddr);
 
 #elif defined(TARGET_WINDOWS)
-  return _InterlockedExchangeAdd(pAddr, amount);
+  _InterlockedExchangeAdd(pAddr, amount);
+  return *pAddr;
 
 #elif defined(__x86_64__)
   long result;
@@ -373,7 +374,8 @@ long AtomicSubtract(volatile long* pAddr, long amount)
 
 #elif defined(TARGET_WINDOWS)
   amount *= -1;
-  return _InterlockedExchangeAdd(pAddr, amount);
+  _InterlockedExchangeAdd(pAddr, amount);
+  return *pAddr;
 
 #elif defined(__x86_64__)
   long result;


### PR DESCRIPTION
`AtomicAdd` & `AtomicSubtract` must return the new value, but `_InterlockedExchangeAdd` returns the old value.