### PR TITLE
fixup! Link against curl instead of using dlopen

### DIFF
--- a/xbmc/filesystem/DllLibCurl.cpp
+++ b/xbmc/filesystem/DllLibCurl.cpp
@@ -49,7 +49,7 @@ extern "C"
       m_sslLockArray[type]->unlock();
   }
 
-  unsigned long ssl_thread_id() { return static_cast<unsigned long>(CThread::GetCurrentThreadId()); }
+  unsigned long ssl_thread_id() { return (unsigned long) CThread::GetCurrentThreadId(); }
 
 #ifdef __cplusplus
 }
@@ -158,11 +158,11 @@ const char* DllLibCurl::easy_strerror(CURLcode code)
 #if defined(HAS_CURL_STATIC)
 void DllLibCurl::crypto_set_id_callback(unsigned long (*cb)())
 {
-  curl_crypto_set_id_callback(cb);
+  CRYPTO_set_id_callback(cb);
 }
 void DllLibCurl::crypto_set_locking_callback(void (*cb)(int, int, const char*, int))
 {
-  curl_crypto_set_locking_callback(cb);
+  CRYPTO_set_locking_callback(cb);
 }
 #endif
 
@@ -192,8 +192,8 @@ DllLibCurlGlobal::~DllLibCurlGlobal()
 
 #if defined(HAS_CURL_STATIC)
   // Cleanup ssl locking array
-  curl_crypto_set_id_callback(NULL);
-  curl_crypto_set_locking_callback(NULL);
+  crypto_set_id_callback(NULL);
+  crypto_set_locking_callback(NULL);
   for (int i = 0; i < CRYPTO_num_locks(); i++)
     delete m_sslLockArray[i];
 

--- a/xbmc/filesystem/DllLibCurl.h
+++ b/xbmc/filesystem/DllLibCurl.h
@@ -20,8 +20,11 @@
  */
 
 #include "threads/CriticalSection.h"
+
 #include <stdio.h>
 #include <string>
+#include <sys/time.h>
+#include <sys/types.h>
 #include <type_traits>
 #include <vector>
 


### PR DESCRIPTION
only compile tested for osx, ios and android

`static_cast` doesn't work on osx and ios as `CThread::GetCurrentThreadId` returns `pthread_t`, but on android it returns `long` so `reinterpret_cast` wouldn't work there.